### PR TITLE
Updates for perf

### DIFF
--- a/client/components/about.jsx
+++ b/client/components/about.jsx
@@ -56,7 +56,7 @@ const About = () => (
           overlay={<CardTitle title="Beer from around the world!" />}
           overlayContentStyle={styles.overlayContentStyle}
         >
-          <img src={`/js/${beerMapImage}`} />
+          <img src={beerMapImage} alt="Beer Map" />
         </CardMedia>
       </Card>
 

--- a/client/components/beer-card.jsx
+++ b/client/components/beer-card.jsx
@@ -15,7 +15,7 @@ export class BeerCard extends React.Component {
     return (
       <Card style={styles.card}>
         <CardMedia>
-          <img src={`/js/${beerIconImage}`} />
+          <img src={beerIconImage} alt="Beer Icon" />
         </CardMedia>
 
         <CardText>

--- a/client/components/header.jsx
+++ b/client/components/header.jsx
@@ -53,7 +53,7 @@ const Header = () => (
         }
         overlayContentStyle={styles.overlayContentStyle}
       >
-        <img src={`/js/${beerImage}`} />
+        <img src={beerImage} alt="beer background" />
       </CardMedia>
     </Card>
   </div>

--- a/client/components/home.jsx
+++ b/client/components/home.jsx
@@ -43,28 +43,28 @@ const styles = {
 };
 
 class HomeWrapper extends React.Component {
-  constructor() {
-    super();
+  // constructor() {
+  //   super();
 
-    fetch("/getBeerStyles", {
-      credentials: "same-origin",
-      method: "GET",
-      headers: {
-        "Accept": "application/json",
-        "Content-Type": "application/json"
-      }
-    })
-    .then((resp) => {
-      if (resp.status === 200) {
-        this.setState({testResult: `GET SUCCEEDED with status ${resp.status}` });
-      } else {
-        this.setState({testResult: `GET FAILED with status ${resp.status}` });
-      }
-    })
-    .catch((e) => {
-      this.setState({testResult: `GET FAILED: ${e.toString()}`});
-    });
-  }
+  //   fetch("/getBeerStyles", {
+  //     credentials: "same-origin",
+  //     method: "GET",
+  //     headers: {
+  //       "Accept": "application/json",
+  //       "Content-Type": "application/json"
+  //     }
+  //   })
+  //   .then((resp) => {
+  //     if (resp.status === 200) {
+  //       this.setState({testResult: `GET SUCCEEDED with status ${resp.status}` });
+  //     } else {
+  //       this.setState({testResult: `GET FAILED with status ${resp.status}` });
+  //     }
+  //   })
+  //   .catch((e) => {
+  //     this.setState({testResult: `GET FAILED: ${e.toString()}`});
+  //   });
+  // }
 
   render() {
     return (
@@ -103,7 +103,7 @@ export class Home extends React.Component {
                   overlay={<CardTitle title="Beer from around the world!" />}
                   overlayContentStyle={styles.overlayContentStyle}
                 >
-                  <img src={`/js/${beerMapImage}`} />
+                  <img src={beerMapImage} alt="Beer Map" />
                 </CardMedia>
               </Card>
               <br />

--- a/server/plugins/webapp/index.html
+++ b/server/plugins/webapp/index.html
@@ -2,14 +2,16 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     {{META_TAGS}}
     <title>{{PAGE_TITLE}}</title>
     {{PREFETCH_BUNDLES}}
-    {{WEBAPP_BUNDLES}}
+    {{WEBAPP_HEADER_BUNDLES}}
     <link href='https://fonts.googleapis.com/css?family=Gabriela|Open+Sans' rel='stylesheet' type='text/css'>
 </head>
 <body>
 <div class="js-content">{{SSR_CONTENT}}</div>
+{{WEBAPP_BODY_BUNDLES}}
 {{REGISTER_SW}}
 <script>if (window.webappStart) webappStart();</script>
 <script>

--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -49,12 +49,12 @@ function getIconStats(iconStatsPath) {
   }
   /* Include the path prefix so the icons resolve */
   if (iconStats && iconStats.html) {
-    const prefix = iconStats.outputFilePrefix;
     iconStats = iconStats.html.join("");
   }
   return iconStats;
 }
 
+/* eslint max-statements: [2, 16] */
 function makeRouteHandler(options, userContent) {
   const CONTENT_MARKER = "{{SSR_CONTENT}}";
   const HEADER_BUNDLE_MARKER = "{{WEBAPP_HEADER_BUNDLES}}";

--- a/server/plugins/webapp/index.js
+++ b/server/plugins/webapp/index.js
@@ -50,16 +50,15 @@ function getIconStats(iconStatsPath) {
   /* Include the path prefix so the icons resolve */
   if (iconStats && iconStats.html) {
     const prefix = iconStats.outputFilePrefix;
-    iconStats = iconStats.html
-      .map((asset) => asset.replace(prefix, `/js/${prefix}`))
-      .join("");
+    iconStats = iconStats.html.join("");
   }
   return iconStats;
 }
 
 function makeRouteHandler(options, userContent) {
   const CONTENT_MARKER = "{{SSR_CONTENT}}";
-  const BUNDLE_MARKER = "{{WEBAPP_BUNDLES}}";
+  const HEADER_BUNDLE_MARKER = "{{WEBAPP_HEADER_BUNDLES}}";
+  const BODY_BUNDLE_MARKER = "{{WEBAPP_BODY_BUNDLES}}";
   const TITLE_MARKER = "{{PAGE_TITLE}}";
   const PREFETCH_MARKER = "{{PREFETCH_BUNDLES}}";
   const REGISTER_SW_MARKER = "{{REGISTER_SW}}";
@@ -104,16 +103,20 @@ function makeRouteHandler(options, userContent) {
       });
     };
 
-    const makeBundles = () => {
+    const makeHeaderBundles = () => {
       const manifest = bundleManifest();
       const manifestLink = manifest
         ? `<link rel="manifest" href="${manifest}" />`
         : "";
       const css = bundleCss();
       const cssLink = css ? `<link rel="stylesheet" href="${css}" />` : "";
+      return `${manifestLink}${cssLink}`;
+    };
+
+    const makeBodyBundles = () => {
       const js = bundleJs();
       const jsLink = js ? `<script src="${js}"></script>` : "";
-      return `${manifestLink}${cssLink}${jsLink}`;
+      return jsLink;
     };
 
     const registerServiceWorker = () => {
@@ -132,8 +135,10 @@ function makeRouteHandler(options, userContent) {
           return content.html || "";
         case TITLE_MARKER:
           return options.pageTitle;
-        case BUNDLE_MARKER:
-          return makeBundles();
+        case HEADER_BUNDLE_MARKER:
+          return makeHeaderBundles();
+        case BODY_BUNDLE_MARKER:
+          return makeBodyBundles();
         case PREFETCH_MARKER:
           return `<script>${content.prefetch}</script>`;
         case REGISTER_SW_MARKER:


### PR DESCRIPTION
I've updated a few things to increase the scores in our Lighthouse report. @ananavati @donsalari

- All images should have alt tags
- Our templates need viewport tags
- Our main JS bundle tag should be at the bottom of the body

Doing these few things brought down our first meaningful paint time from 3500ms to 720ms and our time to interactive from 4500ms to 960ms. Our last goal for perf should be to further increase our perceptual speed index score. 

@aweary I'll also put in a PR to update the boilerplate with these perf goals in mind.

![screen shot 2016-11-17 at 3 03 46 pm](https://cloud.githubusercontent.com/assets/2831294/20411625/206517a6-acd7-11e6-800f-b163aa1aecdc.png)
